### PR TITLE
chore: update service templates to fix some type issues

### DIFF
--- a/packages/generators/src/service/index.ts
+++ b/packages/generators/src/service/index.ts
@@ -52,11 +52,11 @@ export interface ServiceGeneratorContext extends FeathersBaseContext {
   /**
    * Singular version of the service name
    */
-  singluarCamelName: string
+  singularCamelName: string
   /**
    * Singular version of the service name starting with an uppercase letter
    */
-  singluarUpperName: string
+  singularUpperName: string
   /**
    * Indicates how many file paths we should go up to import other things (e.g. `../../`)
    */
@@ -84,7 +84,7 @@ export interface ServiceGeneratorContext extends FeathersBaseContext {
   /**
    * Do not pluralize the input service name, leave as-is
    */
-  singluar?: boolean
+  singular?: boolean
 }
 
 /**
@@ -193,15 +193,15 @@ export const generate = (ctx: ServiceGeneratorArguments) =>
       )
     )
     .then(async (ctx): Promise<ServiceGeneratorContext> => {
-      const { path, type, authStrategies = [], singluar } = ctx
-      const name = !singluar ? pluralize(ctx.name) : ctx.name
+      const { path, type, authStrategies = [], singular } = ctx
+      const name = !singular ? pluralize(ctx.name) : ctx.name
 
       const kebabName = _.kebabCase(name)
       const camelName = _.camelCase(name)
       const upperName = _.upperFirst(camelName)
       const className = `${upperName}Service`
-      const singluarCamelName = pluralize.singular(name)
-      const singluarUpperName = _.upperFirst(singluarCamelName)
+      const singularCamelName = pluralize.singular(name)
+      const singularUpperName = _.upperFirst(singularCamelName)
 
       const folder = path.split('/').filter((el) => el !== '')
       const relative = ['', ...folder].map(() => '..').join('/')
@@ -218,8 +218,8 @@ export const generate = (ctx: ServiceGeneratorArguments) =>
         className,
         kebabName,
         camelName,
-        singluarCamelName,
-        singluarUpperName,
+        singularCamelName,
+        singularUpperName,
         kebabPath,
         relative,
         authStrategies,

--- a/packages/generators/src/service/templates/client.tpl.ts
+++ b/packages/generators/src/service/templates/client.tpl.ts
@@ -8,12 +8,12 @@ import { ${camelName}Client } from './services/${folder.join('/')}/${fileName}.s
 
 const typeExportTemplate = ({
   upperName,
-  singluarUpperName,
+  singularUpperName,
   folder,
   fileName
 }: ServiceGeneratorContext) => /* ts */ `
 export type {
-  ${singluarUpperName},
+  ${singularUpperName},
   ${upperName}Data,
   ${upperName}Query,
   ${upperName}Patch

--- a/packages/generators/src/service/templates/schema.json.tpl.ts
+++ b/packages/generators/src/service/templates/schema.json.tpl.ts
@@ -5,8 +5,8 @@ import { ServiceGeneratorContext } from '../index'
 const template = ({
   camelName,
   upperName,
-  singluarCamelName,
-  singluarUpperName,
+  singularCamelName,
+  singularUpperName,
   fileName,
   relative,
   authStrategies,
@@ -35,14 +35,14 @@ import { dataValidator, queryValidator } from '${relative}/${
 
 // Main data model schema
 
-import { ${singluarCamelName} as ${camelName}Schema } from './${fileName}.schema.gen'
+import { ${singularCamelName} as ${camelName}Schema } from './${fileName}.schema.gen'
 export { ${camelName}Schema };
-export type ${singluarUpperName} = FromSchema<typeof ${camelName}Schema>
+export type ${singularUpperName} = FromSchema<typeof ${camelName}Schema>
 
 export const ${camelName}Validator = getValidator(${camelName}Schema, dataValidator)
-export const ${camelName}Resolver = resolve<${singluarUpperName}, HookContext>({})
+export const ${camelName}Resolver = resolve<${singularUpperName}, HookContext>({})
 
-export const ${camelName}ExternalResolver = resolve<${singluarUpperName}, HookContext>({
+export const ${camelName}ExternalResolver = resolve<${singularUpperName}, HookContext>({
   ${localTemplate(
     authStrategies,
     `// The password should never be visible externally

--- a/packages/generators/src/service/templates/schema.typebox.tpl.ts
+++ b/packages/generators/src/service/templates/schema.typebox.tpl.ts
@@ -31,7 +31,7 @@ import { dataValidator, queryValidator } from '${relative}/${
   fileExists(cwd, lib, 'schemas') ? 'schemas/' : '' /** This is for legacy backwards compatibility */
 }validators'
 
-${schema ? `import { defaultReadonlyFields } from '../configs'`: ''}
+${schema ? `import { defaultReadonlyFields } from '../configs'` : ''}
 import { ${singularCamelName} as ${camelName}Schema } from './${fileName}.schema.gen'
 export { ${camelName}Schema };
 export type ${singularUpperName} = Static<typeof ${camelName}Schema>
@@ -47,7 +47,9 @@ export const ${camelName}ExternalResolver = resolve<${singularUpperName}, HookCo
   )}  
 })
 
-const ${camelName}ReadonlyFields: (keyof ${singularUpperName})[] = ${schema? '[...defaultReadonlyFields]' : '[]'}
+const ${camelName}ReadonlyFields: (keyof ${singularUpperName})[] = ${
+  schema ? '[...defaultReadonlyFields]' : '[]'
+}
 
 /** 
  * @title: ${camelName}DataSchema
@@ -89,7 +91,9 @@ export const ${camelName}PatchResolver = resolve<${singularUpperName}, HookConte
  * @title: ${camelName}QueryProperties
  * @description Schema for allowed query properties 
  */
-export const ${camelName}QueryProperties = Type.Omit(${camelName}Schema, ${type === 'mongodb' ? `['_id']` : '[]'}) ${
+export const ${camelName}QueryProperties = Type.Omit(${camelName}Schema, ${
+  type === 'mongodb' ? `['_id']` : '[]'
+}) ${
   isEntityService
     ? `& Type.Pick(${camelName}Schema, [
   ${authStrategies.map((name) => (name === 'local' ? `'email'` : `'${name}Id'`)).join(', ')}

--- a/packages/generators/src/service/templates/schema.typebox.tpl.ts
+++ b/packages/generators/src/service/templates/schema.typebox.tpl.ts
@@ -11,7 +11,6 @@ const template = ({
   relative,
   authStrategies,
   isEntityService,
-  schema,
   type,
   cwd,
   lib
@@ -31,7 +30,7 @@ import { dataValidator, queryValidator } from '${relative}/${
   fileExists(cwd, lib, 'schemas') ? 'schemas/' : '' /** This is for legacy backwards compatibility */
 }validators'
 
-${schema ? `import { defaultReadonlyFields } from '../configs'` : ''}
+${type === 'custom' ? '' : `import { defaultReadonlyFields } from '../configs'`}
 import { ${singularCamelName} as ${camelName}Schema } from './${fileName}.schema.gen'
 export { ${camelName}Schema };
 export type ${singularUpperName} = Static<typeof ${camelName}Schema>
@@ -48,7 +47,7 @@ export const ${camelName}ExternalResolver = resolve<${singularUpperName}, HookCo
 })
 
 const ${camelName}ReadonlyFields: (keyof ${singularUpperName})[] = ${
-  schema ? '[...defaultReadonlyFields]' : '[]'
+  type === 'custom' ? '[]' : '[...defaultReadonlyFields]'
 }
 
 /** 
@@ -65,6 +64,7 @@ export const ${camelName}DataSchema =  ${isEntityService ? `Type.Pick` : `Type.O
 ], {
   $id: '${upperName}Data'
 })
+// FIXME: this type is '{}' because the readonlyFields have as type all the keys of the schema
 export type ${upperName}Data = Static<typeof ${camelName}DataSchema>
 export const ${camelName}DataValidator = getValidator(${camelName}DataSchema, dataValidator)
 export const ${camelName}DataResolver = resolve<${singularUpperName}, HookContext>({

--- a/packages/generators/src/service/templates/schema.typebox.tpl.ts
+++ b/packages/generators/src/service/templates/schema.typebox.tpl.ts
@@ -5,8 +5,8 @@ import { ServiceGeneratorContext } from '../index'
 const template = ({
   camelName,
   upperName,
-  singluarCamelName,
-  singluarUpperName,
+  singularCamelName,
+  singularUpperName,
   fileName,
   relative,
   authStrategies,
@@ -31,14 +31,14 @@ import { dataValidator, queryValidator } from '${relative}/${
 
 /** Main data model schema */
 import { defaultReadonlyFields } from '../configs'
-import { ${singluarCamelName} as ${camelName}Schema } from './${fileName}.schema.gen'
+import { ${singularCamelName} as ${camelName}Schema } from './${fileName}.schema.gen'
 export { ${camelName}Schema };
-export type ${singluarUpperName} = Static<typeof ${camelName}Schema>
+export type ${singularUpperName} = Static<typeof ${camelName}Schema>
 
 export const ${camelName}Validator = getValidator(${camelName}Schema, dataValidator)
-export const ${camelName}Resolver = resolve<${singluarUpperName}, HookContext>({})
+export const ${camelName}Resolver = resolve<${singularUpperName}, HookContext>({})
 
-export const ${camelName}ExternalResolver = resolve<${singluarUpperName}, HookContext>({
+export const ${camelName}ExternalResolver = resolve<${singularUpperName}, HookContext>({
   ${localTemplate(
     authStrategies,
     `/** The password should never be visible externally */
@@ -46,7 +46,7 @@ export const ${camelName}ExternalResolver = resolve<${singluarUpperName}, HookCo
   )}  
 })
 
-const ${camelName}ReadonlyFields: (keyof ${singluarUpperName})[] = [...defaultReadonlyFields]
+const ${camelName}ReadonlyFields: (keyof ${singularUpperName})[] = [...defaultReadonlyFields]
 
 /** 
  * @title: ${camelName}DataSchema
@@ -64,7 +64,7 @@ export const ${camelName}DataSchema =  ${isEntityService ? `Type.Pick` : `Type.O
 })
 export type ${upperName}Data = Static<typeof ${camelName}DataSchema>
 export const ${camelName}DataValidator = getValidator(${camelName}DataSchema, dataValidator)
-export const ${camelName}DataResolver = resolve<${singluarUpperName}, HookContext>({
+export const ${camelName}DataResolver = resolve<${singularUpperName}, HookContext>({
   ${localTemplate(authStrategies, `password: passwordHash({ strategy: 'local' })`)}
 })
 
@@ -80,7 +80,7 @@ export const ${camelName}PatchSchema = Type.Partial(
   })
 export type ${upperName}Patch = Static<typeof ${camelName}PatchSchema>
 export const ${camelName}PatchValidator = getValidator(${camelName}PatchSchema, dataValidator)
-export const ${camelName}PatchResolver = resolve<${singluarUpperName}, HookContext>({
+export const ${camelName}PatchResolver = resolve<${singularUpperName}, HookContext>({
   ${localTemplate(authStrategies, `password: passwordHash({ strategy: 'local' })`)}
 })
 

--- a/packages/generators/src/service/templates/service.tpl.ts
+++ b/packages/generators/src/service/templates/service.tpl.ts
@@ -12,7 +12,8 @@ export const template = ({
   className,
   relative,
   schema,
-  fileName
+  fileName,
+  type
 }: ServiceGeneratorContext) => /* ts */ `/**
  * @external https://feathersjs.com/guides/cli/service.html
  * @description For more information about this file see the link above.
@@ -64,7 +65,11 @@ export const ${camelName} = (app: Application) => {
     events: []
   })
   /** Initialize hooks */
-  // @ts-expect-error [ENG-770] FIXME: Types of property 'update' are incompatible: NullableId vs AdapterId
+  ${
+    type === 'mongodb'
+      ? `// @ts-expect-error [ENG-770] FIXME: Types of property 'update' are incompatible: NullableId vs AdapterId`
+      : ''
+  }
   app.service(${camelName}Path).hooks({
     around: {
       all: [${

--- a/packages/generators/src/service/templates/service.tpl.ts
+++ b/packages/generators/src/service/templates/service.tpl.ts
@@ -17,6 +17,8 @@ export const template = ({
  * @external https://feathersjs.com/guides/cli/service.html
  * @description For more information about this file see the link above.
  */
+import type { Application } from '${relative}/declarations'
+
 ${authentication || isEntityService ? `import { authenticate } from '@feathersjs/authentication'` : ''}
 ${
   schema
@@ -37,7 +39,6 @@ import {
     : ''
 }
 
-import type { Application } from '${relative}/declarations'
 import { ${className}, getOptions } from './${fileName}.class'
 ${
   fileExists(lib, `client.${language}`)

--- a/packages/generators/src/service/templates/shared.tpl.ts
+++ b/packages/generators/src/service/templates/shared.tpl.ts
@@ -5,7 +5,7 @@ import { ServiceGeneratorContext } from '../index'
 const sharedTemplate = ({
   camelName,
   upperName,
-  singluarUpperName,
+  singularUpperName,
   className,
   fileName,
   relative,
@@ -18,14 +18,14 @@ const sharedTemplate = ({
 import type { Params } from '@feathersjs/feathers'
 import type { ClientApplication } from '${relative}/client'
 import type {
-  ${singluarUpperName},
+  ${singularUpperName},
   ${upperName}Data,
   ${upperName}Patch,
   ${upperName}Query,
   ${className}
 } from './${fileName}.class'
 
-export type { ${singluarUpperName}, ${upperName}Data, ${upperName}Patch, ${upperName}Query }
+export type { ${singularUpperName}, ${upperName}Data, ${upperName}Patch, ${upperName}Query }
 
 export type ${upperName}ClientService = Pick<
   ${className}<Params<${upperName}Query>>,

--- a/packages/generators/src/service/templates/test.tpl.ts
+++ b/packages/generators/src/service/templates/test.tpl.ts
@@ -8,6 +8,7 @@ const template = ({ relative, lib, path }: ServiceGeneratorContext) => /* ts */ 
  */
 
 import { describe, expect, test } from 'vitest';
+
 import { app } from '../${relative}/${lib}/app'
 
 describe('${path} service', () => {

--- a/packages/generators/src/service/type/custom.tpl.ts
+++ b/packages/generators/src/service/type/custom.tpl.ts
@@ -15,7 +15,6 @@ export const template = ({
  */
 
 import type { Id, NullableId, Params, ServiceInterface } from '@feathersjs/feathers'
-
 import type { Application } from '${relative}/declarations'
 ${
   schema
@@ -50,20 +49,20 @@ export class ${className}<ServiceParams extends ${upperName}Params = ${upperName
   constructor (public options: ${className}Options) {
   }
 
-  async find (_params?: ServiceParams): Promise<${upperName}[]> {
+  async find (_params?: ServiceParams): Promise<${singularUpperName}[]> {
     return []
   }
 
-  async get (id: Id, _params?: ServiceParams): Promise<${upperName}> {
+  async get (id: Id, _params?: ServiceParams): Promise<${singularUpperName}> {
     return {
       id: 0,
       text: \`A new message with ID: \${id}!\`
     }
   }
 
-  async create (data: ${upperName}Data, params?: ServiceParams): Promise<${upperName}>
-  async create (data: ${upperName}Data[], params?: ServiceParams): Promise<${upperName}[]>
-  async create (data: ${upperName}Data|${upperName}Data[], params?: ServiceParams): Promise<${upperName}|${upperName}[]> {
+  async create (data: ${upperName}Data, params?: ServiceParams): Promise<${singularUpperName}>
+  async create (data: ${upperName}Data[], params?: ServiceParams): Promise<${singularUpperName}[]>
+  async create (data: ${upperName}Data|${upperName}Data[], params?: ServiceParams): Promise<${singularUpperName}|${singularUpperName}[]> {
     if (Array.isArray(data)) {
       return Promise.all(data.map(current => this.create(current, params)));
     }
@@ -75,14 +74,14 @@ export class ${className}<ServiceParams extends ${upperName}Params = ${upperName
   }
 
   // This method has to be added to the 'methods' option to make it available to clients
-  async update (id: NullableId, data: ${upperName}Data, _params?: ServiceParams): Promise<${upperName}> {
+  async update (id: NullableId, data: ${upperName}Data, _params?: ServiceParams): Promise<${singularUpperName}> {
     return {
       id: 0,
       ...data
     }
   }
 
-  async patch (id: NullableId, data: ${upperName}Patch, _params?: ServiceParams): Promise<${upperName}> {
+  async patch (id: NullableId, data: ${upperName}Patch, _params?: ServiceParams): Promise<${singularUpperName}> {
     return {
       id: 0,
       text: \`Fallback for \${id}\`,
@@ -90,7 +89,7 @@ export class ${className}<ServiceParams extends ${upperName}Params = ${upperName
     }
   }
 
-  async remove (id: NullableId, _params?: ServiceParams): Promise<${upperName}> {
+  async remove (id: NullableId, _params?: ServiceParams): Promise<${singularUpperName}> {
     return {
       id: 0,
       text: 'removed'

--- a/packages/generators/src/service/type/custom.tpl.ts
+++ b/packages/generators/src/service/type/custom.tpl.ts
@@ -5,7 +5,7 @@ import { ServiceGeneratorContext } from '../index'
 export const template = ({
   className,
   upperName,
-  singluarUpperName,
+  singularUpperName,
   schema,
   fileName,
   relative
@@ -20,7 +20,7 @@ import type { Application } from '${relative}/declarations'
 ${
   schema
     ? `import type {
-  ${singluarUpperName},
+  ${singularUpperName},
   ${upperName}Data,
   ${upperName}Patch,
   ${upperName}Query
@@ -34,7 +34,7 @@ type ${upperName}Query = any
 `
 }
 
-export type { ${singluarUpperName}, ${upperName}Data, ${upperName}Patch, ${upperName}Query }
+export type { ${singularUpperName}, ${upperName}Data, ${upperName}Patch, ${upperName}Query }
 
 export interface ${className}Options {
   app: Application
@@ -46,7 +46,7 @@ export interface ${upperName}Params extends Params<${upperName}Query> {
 
 // This is a skeleton for a custom service class. Remove or add the methods you need here
 export class ${className}<ServiceParams extends ${upperName}Params = ${upperName}Params>
-    implements ServiceInterface<${singluarUpperName}, ${upperName}Data, ServiceParams, ${upperName}Patch> {
+    implements ServiceInterface<${singularUpperName}, ${upperName}Data, ServiceParams, ${upperName}Patch> {
   constructor (public options: ${className}Options) {
   }
 

--- a/packages/generators/src/service/type/custom.tpl.ts
+++ b/packages/generators/src/service/type/custom.tpl.ts
@@ -57,7 +57,7 @@ export class ${className}<ServiceParams extends ${upperName}Params = ${upperName
     return {
       id: 0,
       text: \`A new message with ID: \${id}!\`
-    }
+    } as ${singularUpperName}
   }
 
   async create (data: ${upperName}Data, params?: ServiceParams): Promise<${singularUpperName}>
@@ -70,7 +70,7 @@ export class ${className}<ServiceParams extends ${upperName}Params = ${upperName
     return {
       id: 0,
       ...data
-    }
+    } as ${singularUpperName}
   }
 
   // This method has to be added to the 'methods' option to make it available to clients
@@ -78,7 +78,7 @@ export class ${className}<ServiceParams extends ${upperName}Params = ${upperName
     return {
       id: 0,
       ...data
-    }
+    } as ${singularUpperName}
   }
 
   async patch (id: NullableId, data: ${upperName}Patch, _params?: ServiceParams): Promise<${singularUpperName}> {
@@ -86,14 +86,14 @@ export class ${className}<ServiceParams extends ${upperName}Params = ${upperName
       id: 0,
       text: \`Fallback for \${id}\`,
       ...data
-    }
+    } as ${singularUpperName}
   }
 
   async remove (id: NullableId, _params?: ServiceParams): Promise<${singularUpperName}> {
     return {
       id: 0,
       text: 'removed'
-    }
+    } as ${singularUpperName}
   }
 }
 

--- a/packages/generators/src/service/type/knex.tpl.ts
+++ b/packages/generators/src/service/type/knex.tpl.ts
@@ -42,7 +42,7 @@ export async function down(knex: Knex): Promise<void> {
 export const template = ({
   className,
   upperName,
-  singluarUpperName,
+  singularUpperName,
   feathers,
   schema,
   fileName,
@@ -60,7 +60,7 @@ import type { Application } from '${relative}/declarations'
 ${
   schema
     ? `import type {
-  ${singluarUpperName},
+  ${singularUpperName},
   ${upperName}Data,
   ${upperName}Patch,
   ${upperName}Query
@@ -74,14 +74,14 @@ type ${upperName}Query = any
 `
 }
 
-export type { ${singluarUpperName}, ${upperName}Data, ${upperName}Patch, ${upperName}Query }
+export type { ${singularUpperName}, ${upperName}Data, ${upperName}Patch, ${upperName}Query }
 
 export interface ${upperName}Params extends KnexAdapterParams<${upperName}Query> {
 }
 
 // By default calls the standard Knex adapter service methods but can be customized with your own functionality.
 export class ${className}<ServiceParams extends Params = ${upperName}Params>
-  extends KnexService<${singluarUpperName}, ${upperName}Data, ${upperName}Params, ${upperName}Patch> {
+  extends KnexService<${singularUpperName}, ${upperName}Data, ${upperName}Params, ${upperName}Patch> {
 }
 
 export const getOptions = (app: Application): KnexAdapterOptions => {

--- a/packages/generators/src/service/type/mongodb.tpl.ts
+++ b/packages/generators/src/service/type/mongodb.tpl.ts
@@ -5,7 +5,7 @@ import { ServiceGeneratorContext } from '../index'
 export const template = ({
   className,
   upperName,
-  singluarUpperName,
+  singularUpperName,
   schema,
   fileName,
   kebabPath,
@@ -23,7 +23,7 @@ import type { Application } from '${relative}/declarations'
 ${
   schema
     ? `import type {
-  ${singluarUpperName},
+  ${singularUpperName},
   ${upperName}Data,
   ${upperName}Patch,
   ${upperName}Query
@@ -37,7 +37,7 @@ type ${upperName}Query = any
 `
 }
 
-export type { ${singluarUpperName}, ${upperName}Data, ${upperName}Patch, ${upperName}Query }
+export type { ${singularUpperName}, ${upperName}Data, ${upperName}Patch, ${upperName}Query }
 
 export interface ${upperName}Params extends MongoDBAdapterParams<${upperName}Query> {
 }
@@ -47,7 +47,7 @@ export interface ${upperName}Params extends MongoDBAdapterParams<${upperName}Que
  * customized with your own functionality.
  */
 export class ${className}<ServiceParams extends Params = ${upperName}Params>
-  extends MongoDBService<${singluarUpperName}, ${upperName}Data, ServiceParams, ${upperName}Patch> {
+  extends MongoDBService<${singularUpperName}, ${upperName}Data, ServiceParams, ${upperName}Patch> {
 }
 
 export const getOptions = (app: Application): MongoDBAdapterOptions => {

--- a/packages/generators/src/service/type/mongodb.tpl.ts
+++ b/packages/generators/src/service/type/mongodb.tpl.ts
@@ -16,9 +16,7 @@ export const template = ({
  */
 
 import type { Params } from '@feathersjs/feathers'
-import { MongoDBService } from \'@feathersjs/mongodb\'
 import type { MongoDBAdapterParams, MongoDBAdapterOptions } from \'@feathersjs/mongodb\'
-
 import type { Application } from '${relative}/declarations'
 ${
   schema
@@ -37,6 +35,8 @@ type ${upperName}Query = any
 `
 }
 
+import { MongoDBService } from \'@feathersjs/mongodb\'
+
 export type { ${singularUpperName}, ${upperName}Data, ${upperName}Patch, ${upperName}Query }
 
 export interface ${upperName}Params extends MongoDBAdapterParams<${upperName}Query> {
@@ -53,8 +53,8 @@ export class ${className}<ServiceParams extends Params = ${upperName}Params>
 export const getOptions = (app: Application): MongoDBAdapterOptions => {
   return {
     id: 'uuid',
-    paginate: app.get('paginate'),
     Model: app.get('mongodbClient').then(db => db.collection('${kebabPath}'))
+    paginate: app.get('paginate'),
   }
 }
 `

--- a/packages/generators/src/service/type/mongodb.tpl.ts
+++ b/packages/generators/src/service/type/mongodb.tpl.ts
@@ -53,7 +53,7 @@ export class ${className}<ServiceParams extends Params = ${upperName}Params>
 export const getOptions = (app: Application): MongoDBAdapterOptions => {
   return {
     id: 'uuid',
-    Model: app.get('mongodbClient').then(db => db.collection('${kebabPath}'))
+    Model: app.get('mongodbClient').then(db => db.collection('${kebabPath}')),
     paginate: app.get('paginate'),
   }
 }


### PR DESCRIPTION
### Summary

This PR updates the services templates to fix some type issues:
1. singular name has to be used in the service methods return type from the custom class file. Only the import was singular but the usage was plural, causing errors.
2. error in patchSchema where wrong format param was given to Type.Omit
3. set readOnlyFields to empty for custom services
4. fixed singular typo which was causing the option not to work